### PR TITLE
[DSIO-8] Update documentation and accuracy pass across power analysis and GCP pipeline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ python gcp/deploy/manage_compute.py setup|status|ssh|scp|teardown  # Compute Eng
 
 Four Cloud Run functions: `run_qualtrics_scheduling` (HTTP) → `run_intake_confirmation` (Pub/Sub) → `run_followup_scheduling` (Pub/Sub) form the scheduling chain. `run_followup_response` (HTTP) is a terminal inbound endpoint — Qualtrics posts completed followup survey responses (9AM/1PM/5PM) directly to it; it validates and writes to BigQuery with no downstream publishing. API Gateway fronts function 1 with `x-api-key` validation and IAM JWT injection.
 
-Power analysis: `main.sh` → `run_power_analysis.r` → parallel `simr` simulations (Arend & Schafer 2019). Dev: 3 combos × 10 sims. Prod: 3,645 cells × 1,000 sims on GCP `c3-highcpu-176`.
+Power analysis: `main.sh` → `run_power_analysis.R` → parallel `simr` simulations (Arend & Schafer 2019). Dev: 3 combos × 10 sims. Prod (local): 1,215 cells × 1,000 sims. Prod GCP (`prod_gcp`): 3,645 cells × 1,000 sims on `c3-highcpu-176`.
 
 ## Dependency freeze
 
@@ -64,7 +64,8 @@ Both lock files are frozen against accidental changes. Guardrails in place:
 
 After Python changes: `poetry check --lock` → `poetry run pytest gcp/tests/ -v` → `ruff check . && ruff format --check .` → `sqlfmt --check .`
 After R changes: `bash analysis/tests/validate_r_structure.sh`
-Schema changes: `models/qualtrics.py` → `bq_schemas.py` → `web_service_payload.json` → `test_models.py` → `manage_infra.py teardown/setup`
+Schema changes (intake): `models/qualtrics.py` → `bq_schemas.py` → `web_service_payload.json` → `test_models.py` → `manage_infra.py teardown/setup`
+Schema changes (followup): `models/followup.py` → `bq_schemas.py` → `followup_web_service_payload.json` → `test_followup_response.py` → `manage_infra.py teardown/setup`
 
 ## Workflow
 

--- a/Makefile
+++ b/Makefile
@@ -25,11 +25,11 @@ FN ?= run_qualtrics_scheduling
         power_visual \
         synthetic_analysis synthetic_eda synthetic_measurement \
         synthetic_mlm synthetic_correlation \
-        py_install py_lint py_format py_sqlfmt py_test \
+        py_lint py_format py_sqlfmt py_test \
         gcp_dev gcp_deploy \
-        gcp_infra_up gcp_infra_down \
-        gcp_gateway_up gcp_gateway_test gcp_gateway_down \
-        gcp_pubsub_up gcp_pubsub_down \
+        gcp_infra_up gcp_infra_status gcp_infra_down \
+        gcp_gateway_up gcp_gateway_status gcp_gateway_test gcp_gateway_down \
+        gcp_pubsub_up gcp_pubsub_status gcp_pubsub_down \
         gcp_compute_up gcp_compute_status gcp_compute_ssh \
         gcp_compute_scp gcp_compute_down \
         setup_hooks \
@@ -94,9 +94,9 @@ help:
 	@echo ""
 	@echo "📊 POWER ANALYSIS  (Arend & Schafer 2019)"
 	@echo "   make power_analysis_dev          Dev grid, foreground (~seconds)"
-	@echo "   make power_analysis_prod         Full local grid, background (~hours)"
-	@echo "   make power_analysis_gcp_benchmark GCP timing probe (14 workers)"
-	@echo "   make power_analysis_gcp_prod     GCP full grid (174 workers)"
+	@echo "   make power_analysis_prod         Full local grid, 1,215 cells, background (~hours)"
+	@echo "   make power_analysis_gcp_benchmark GCP timing probe; prod ~= benchmark x 100"
+	@echo "   make power_analysis_gcp_prod     GCP full grid, 3,645 cells, background"
 	@echo "   make power_visual                Power curve figures (after any run)"
 	@echo ""
 	@echo "🔬 SYNTHETIC DATA ANALYSIS"
@@ -138,25 +138,31 @@ help_gcp:
 	@echo "     run_qualtrics_scheduling   HTTP trigger, fronted by API Gateway"
 	@echo "     run_intake_confirmation    Pub/Sub trigger"
 	@echo "     run_followup_scheduling    Pub/Sub trigger"
+	@echo "     run_followup_response      HTTP trigger, terminal inbound (/followup path)"
 	@echo ""
 	@echo "   Dev server:    make gcp_dev FN=run_qualtrics_scheduling"
 	@echo "   Deploy:        make gcp_deploy FN=run_qualtrics_scheduling"
 	@echo ""
 	@echo "   Infrastructure:"
 	@echo "     make gcp_infra_up          Create BigQuery tables"
+	@echo "     make gcp_infra_status      Show table state"
 	@echo "     make gcp_infra_down        Tear down BigQuery tables"
 	@echo "     make gcp_pubsub_up         Create Pub/Sub topics"
+	@echo "     make gcp_pubsub_status     Show topic state and subscriptions"
 	@echo "     make gcp_pubsub_down       Tear down Pub/Sub topics"
 	@echo ""
 	@echo "   API Gateway:"
 	@echo "     make gcp_gateway_up        Set up API Gateway"
+	@echo "     make gcp_gateway_status    Show current gateway resource state"
 	@echo "     make gcp_gateway_test      End-to-end test (fixed survey times)"
 	@echo "     make gcp_gateway_test NOW=1  E2E test (schedule at now+16/32/48 min)"
 	@echo "     make gcp_gateway_down      Tear down API Gateway"
 	@echo ""
 	@echo "   Schema change workflow:"
-	@echo "     models/qualtrics.py → bq_schemas.py → web_service_payload.json"
-	@echo "     → test_models.py → make gcp_infra_down && make gcp_infra_up"
+	@echo "     Intake:   models/qualtrics.py → bq_schemas.py → web_service_payload.json"
+	@echo "               → test_models.py → make gcp_infra_down && make gcp_infra_up"
+	@echo "     Followup: models/followup.py → bq_schemas.py → followup_web_service_payload.json"
+	@echo "               → test_followup_response.py → make gcp_infra_down && make gcp_infra_up"
 	@echo ""
 
 # ---------------------------------------------------------------------------
@@ -227,7 +233,7 @@ setup_hooks:
 validate:
 	@echo "✅ Running static structure validation (no packages needed)..."
 	@echo ""
-	@cd "$(ROOT)/analysis/tests" && bash validate_r_structure.sh || { \
+	@bash "$(ROOT)/analysis/tests/validate_r_structure.sh" || { \
 		echo ""; \
 		echo "❌ Validation failed. Fix reported issues before running analyses."; \
 		exit 1; \
@@ -389,17 +395,6 @@ synthetic_analysis: synthetic_eda synthetic_correlation synthetic_measurement sy
 # Python Dev
 # ---------------------------------------------------------------------------
 
-py_install:
-	@cd "$(ROOT)" && poetry check --lock || { \
-		echo "❌ poetry.lock is out of sync with pyproject.toml."; \
-		echo "   Run: poetry lock --no-update"; \
-		exit 1; \
-	}
-	@echo "📦 Installing all Python dependency groups..."
-	@cd "$(ROOT)" && poetry install \
-		--with fn-qualtrics-scheduling,fn-intake-confirmation,fn-followup-scheduling,fn-followup-response,dev
-	@echo "✅ Python dependencies installed."
-
 py_lint:
 	@echo "🔍 Running ruff check..."
 	@cd "$(ROOT)" && poetry run ruff check . && echo "✅ ruff check passed"
@@ -442,6 +437,10 @@ gcp_infra_up:
 	@echo "🏗️  Setting up BigQuery tables..."
 	@cd "$(ROOT)" && python gcp/deploy/manage_infra.py setup
 
+gcp_infra_status:
+	@echo "🔍 BigQuery table state..."
+	@cd "$(ROOT)" && python gcp/deploy/manage_infra.py status
+
 gcp_infra_down:
 	@echo "🗑️  Tearing down BigQuery tables..."
 	@cd "$(ROOT)" && python gcp/deploy/manage_infra.py teardown
@@ -449,6 +448,10 @@ gcp_infra_down:
 gcp_gateway_up:
 	@echo "🌐 Setting up API Gateway..."
 	@cd "$(ROOT)" && python gcp/deploy/manage_gateway.py setup
+
+gcp_gateway_status:
+	@echo "🔍 API Gateway resource state..."
+	@cd "$(ROOT)" && python gcp/deploy/manage_gateway.py status
 
 gcp_gateway_test:
 	@echo "🧪 Running end-to-end gateway test..."
@@ -467,6 +470,10 @@ gcp_gateway_down:
 gcp_pubsub_up:
 	@echo "📨 Setting up Pub/Sub topics..."
 	@cd "$(ROOT)" && python gcp/deploy/manage_pubsub.py setup
+
+gcp_pubsub_status:
+	@echo "🔍 Pub/Sub topic state..."
+	@cd "$(ROOT)" && python gcp/deploy/manage_pubsub.py status
 
 gcp_pubsub_down:
 	@echo "🗑️  Tearing down Pub/Sub topics..."
@@ -529,6 +536,7 @@ clean:
 	@find "$(ROOT)" -name "*.tmp" -delete 2>/dev/null || true
 	@find "$(ROOT)" -name ".Rhistory" -delete 2>/dev/null || true
 	@find "$(ROOT)" -name "Rplots.pdf" -delete 2>/dev/null || true
+	@find "$(ROOT)" -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
 	@echo "✅ Cleanup complete."
 
 welcome:

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ make gcp_pubsub_up                         # Pub/Sub topics
 make gcp_deploy FN=run_qualtrics_scheduling
 make gcp_deploy FN=run_intake_confirmation
 make gcp_deploy FN=run_followup_scheduling
+make gcp_deploy FN=run_followup_response
 make gcp_gateway_up                        # API Gateway (last — needs functions deployed)
 ```
 

--- a/analysis/CLAUDE.md
+++ b/analysis/CLAUDE.md
@@ -1,21 +1,27 @@
 # analysis/CLAUDE.md
 
-R (4.4, renv) analysis pipeline. Two active pillars:
-- `run_power_analysis/` — multilevel power simulations (Arend & Schafer 2019)
-- `run_synthetic_data/` — test/synthetic ESM data generation
+R (4.4, renv) analysis pipeline. Two pillars:
+- `run_power_analysis/` — multilevel sensitivity analysis (Arend & Schafer 2019); see `run_power_analysis/README.md`
+- `run_synthetic_data/` — synthetic ESM data generation (Python + R + SQL + bash)
 
-Shared utilities in `analysis/shared/utils/common_utils.r`.
+Shared utilities in `analysis/shared/utils/`:
+- `common_utils.r` — `log_msg()`, `load_config()`, `ensure_dir()`, `get_system_info()`
+- `mlm_utils.r` — multilevel model helpers
+- `plot_utils.r` — ggplot2 theme and palette utilities
 
 ## Commands
 
+Run from project root:
+
 ```bash
-Rscript -e "renv::restore()"                               # restore packages from renv.lock
-make renv_snapshot                                         # update renv.lock (sanctioned path)
-bash run_power_analysis/main.sh dev                        # dev grid (seconds)
-bash run_power_analysis/main.sh prod                       # full grid (hours)
-bash run_power_analysis/main.sh benchmark_gcp              # GCP timing probe
-bash run_power_analysis/main.sh prod_gcp                   # GCP full grid (3,645 cells)
-bash analysis/tests/validate_r_structure.sh                # pre-flight; run from project root
+Rscript -e "renv::restore()"                                           # restore from renv.lock
+make renv_snapshot                                                      # update renv.lock (sanctioned)
+bash analysis/run_power_analysis/main.sh dev                           # dev grid (seconds)
+bash analysis/run_power_analysis/main.sh prod                          # full local grid (hours)
+bash analysis/run_power_analysis/main.sh benchmark_gcp                 # GCP timing probe (prod ~= benchmark x 100)
+bash analysis/run_power_analysis/main.sh prod_gcp                      # GCP full grid (3,645 cells)
+Rscript analysis/run_power_analysis/scripts/visualize_power_analysis.R # SVG figures from latest results
+bash analysis/tests/validate_r_structure.sh                            # pre-flight static validation
 ```
 
 ## R conventions
@@ -25,15 +31,9 @@ bash analysis/tests/validate_r_structure.sh                # pre-flight; run fro
 - **Section headers**: `# [1] Section Name ---` numbered, consistent depth
 - **Path resolution**: always resolve from script location — never rely on working directory
 - **Config**: load via `load_config()` from `common_utils.r`; values at `config$params$*`
-- **Logging**: use `log_msg()` — never bare `print()` or `cat()` in scripts
+- **Logging**: `log_msg()` only — never bare `print()` or `cat()` in scripts
 - **Parallel**: `furrr::future_map_dfr()` with `tryCatch()` wrappers in the mapping function
-- **Output**: always timestamp filenames; write `.rds` + `.csv` pairs
-  - **Visuals**: always use SVG as the output for visuals never PDFs unless explicitly directed
-
-## SQL (sqlfmt)
-
-- Line length: 120 chars (configured in root `pyproject.toml`)
-- Format before committing: `poetry run sqlfmt .` (run from project root)
+- **Output**: timestamp filenames; write `.rds` + `.csv` pairs; figures as SVG (never PDF)
 
 ## Variable naming
 
@@ -43,24 +43,9 @@ bash analysis/tests/validate_r_structure.sh                # pre-flight; run fro
 
 ## renv freeze
 
-`renv.lock` is frozen. In interactive R sessions, `renv::snapshot()` and `renv::update()` will error unless explicitly opted in. `renv::restore()` is unaffected.
+`renv.lock` is frozen. In interactive R sessions, `renv::snapshot()` and `renv::update()` error unless opted in. `renv::restore()` is unaffected.
 
-- **Sanctioned snapshot path**: `make renv_snapshot` (sets `RENV_ALLOW_SNAPSHOT=1` automatically)
+- **Sanctioned path**: `make renv_snapshot` (sets `RENV_ALLOW_SNAPSHOT=1`)
 - **Manual opt-in**: `Sys.setenv(RENV_ALLOW_SNAPSHOT = "1"); renv::snapshot()`
-- **Commit the lock update**: `ALLOW_LOCK_COMMIT=1 git commit`
-
-## GCP VM workflow
-
-For large grids, provision a GCP Compute Engine VM via `manage_compute.py`:
-1. `python gcp/deploy/manage_compute.py setup` — creates VM + `gcp/deploy/setup_gcp_vm.sh`
-2. SSH in, run `make power_analysis_gcp_prod` (or `benchmark_gcp` first to calibrate)
-3. `python gcp/deploy/manage_compute.py scp` — download results
-4. `python gcp/deploy/manage_compute.py teardown` — delete VM
-
-Machine type and zone are configured in `gcp/deploy/compute.yaml`.
-
-## Worktree notes
-
-- `renv.lock` is frozen — do not run `renv::snapshot()` in a worktree session without opt-in
-- Run `renv::restore()` once per worktree checkout; it is unaffected by the freeze guard
-- Simulation output (`data/`) is gitignored; each worktree produces independent output
+- **Commit**: `ALLOW_LOCK_COMMIT=1 git commit`
+- **Worktrees**: run `renv::restore()` once per checkout; `data/` output is gitignored per worktree

--- a/analysis/run_power_analysis/README.md
+++ b/analysis/run_power_analysis/README.md
@@ -28,13 +28,13 @@ Rather than solving a closed-form equation, it uses Monte Carlo simulation to em
 
 The program builds a full factorial grid from configuration parameters, distributes the grid across parallel workers via `furrr`, and saves timestamped results. It is designed to run from the command line, eliminating the need for IDEs (e.g., RStudio, VS Code).
 
-The architecture follows a thin-wrapper pattern: [`main.sh`](main.sh) handles process lifecycle (log file creation, wall-clock timing), while [`run_power_analysis.r`](scripts/run_power_analysis.r) owns all application logic (path resolution, configuration, renv activation, parallel execution, and output).
+The architecture follows a thin-wrapper pattern: [`main.sh`](main.sh) handles process lifecycle (log file creation, wall-clock timing), while [`run_power_analysis.R`](scripts/run_power_analysis.R) owns all application logic (path resolution, configuration, renv activation, parallel execution, and output).
 
-Key entry points: [`main.sh`](main.sh) (bash wrapper) and [`scripts/run_power_analysis.r`](scripts/run_power_analysis.r) (orchestrator). The simulation engine lives in [`utils/power_analysis_utils.r`](utils/power_analysis_utils.r). Runtime directories (`data/`, `logs/`, `figs/`) are created automatically and gitignored.
+Key entry points: [`main.sh`](main.sh) (bash wrapper), [`scripts/run_power_analysis.R`](scripts/run_power_analysis.R) (orchestrator), and [`scripts/visualize_power_analysis.R`](scripts/visualize_power_analysis.R) (visualization). The visualizer auto-detects the most recent results file, produces SVG power curve figures saved to `figs/`, and scales from dev to prod grids without changes. The simulation engine lives in [`utils/power_analysis_utils.R`](utils/power_analysis_utils.R). Runtime directories (`data/`, `logs/`, `figs/`) are created automatically and gitignored.
 
 ## How it works
 
-The simulation engine ([`power_analysis_utils.r`](utils/power_analysis_utils.r)) implements the Arend & Schafer (2019) procedure for each parameter combination in the grid. The process has five steps.
+The simulation engine ([`power_analysis_utils.R`](utils/power_analysis_utils.R)) implements the Arend & Schafer (2019) procedure for each parameter combination in the grid. The process has five steps.
 
 **Step 1: Derive variance components.** Starting from standardized inputs (ICC, standardized effect sizes, random slope variance), the function computes unconditional and conditional variance components using Arend & Schafer's equations 10-11. Unconditional Level 1 variance is fixed at 1.00 as the standardization anchor. Level 2 unconditional variance is derived from the ICC as `icc / (1 - icc)`. Conditional variances account for the variance explained by each predictor.
 
@@ -44,7 +44,7 @@ The simulation engine ([`power_analysis_utils.r`](utils/power_analysis_utils.r))
 
 **Step 4: Run Monte Carlo power simulations.** For each of three fixed effects (L1 direct effect of `x`, L2 direct effect of `Z`, cross-level interaction `x:Z`), `simr::powerSim()` generates `n_sims` datasets from the population model, fits the mixed model to each, and tests significance using Kenward-Roger. Power is the proportion of simulations that reject the null.
 
-**Step 5: Return results.** Each combination produces power estimates with 95% confidence intervals for all three effects. The grid runner ([`run_power_analysis.r`](scripts/run_power_analysis.r)) collects these into a single data frame with full parameter context, timing, and success/failure status.
+**Step 5: Return results.** Each combination produces power estimates with 95% confidence intervals for all three effects. The grid runner ([`run_power_analysis.R`](scripts/run_power_analysis.R)) collects these into a single data frame with full parameter context, timing, and success/failure status.
 
 ## Requirements
 
@@ -92,13 +92,13 @@ The program uses YAML configuration files in [`configs/`](configs/) to define th
 
 **[`run_power_analysis.prod.yaml`](configs/run_power_analysis.prod.yaml)**: The full factorial grid used for the dissertation. Crosses 5 Level 2 sample sizes (200-1000) with 3 values each for Level 1 effect size, Level 2 effect size, cross-level effect size, ICC, and random slope variance, yielding **1,215 combinations at 1,000 simulations each**.
 
-**[`run_power_analysis.benchmark_gcp.yaml`](configs/run_power_analysis.benchmark_gcp.yaml)**: A timing probe for GCP VMs. Uses the full effect-size grid with 3 Level 2 sizes, yielding **729 combinations at 50 simulations each**. Uses 14 workers (matching local benchmarks for direct speed comparison). Run this first on a new VM to calibrate expected runtime.
+**[`run_power_analysis.benchmark_gcp.yaml`](configs/run_power_analysis.benchmark_gcp.yaml)**: A timing probe for any VM. Uses the full effect-size grid with 3 Level 2 sizes, yielding **729 combinations at 50 simulations each**. Uses auto-detected workers. Run this first on a new VM to calibrate expected runtime: `prod_min ≈ benchmark_min × 100` (the benchmark grid is 100× smaller than prod_gcp -- 729 cells × 50 sims vs 3,645 cells × 1,000 sims -- at the same worker count).
 
-**[`run_power_analysis.prod_gcp.yaml`](configs/run_power_analysis.prod_gcp.yaml)**: The expanded GCP grid. Crosses 15 Level 2 sample sizes (100-1500 by 100) with the same effect-size grid as prod, yielding **3,645 combinations at 1,000 simulations each**. Configured for 174 workers on a `c3-highcpu-176` instance.
+**[`run_power_analysis.prod_gcp.yaml`](configs/run_power_analysis.prod_gcp.yaml)**: The expanded GCP grid. Crosses 15 Level 2 sample sizes (100-1500 by 100) with the same effect-size grid as prod, yielding **3,645 combinations at 1,000 simulations each**. Auto-detects workers on any instance; on a `c3-highcpu-176` this yields 174 workers (176 vCPUs - 2).
 
 | Parameter         | Description                                            |
 | ----------------- | ------------------------------------------------------ |
-| `max_cores`       | Max parallel workers (NULL = conservative default)     |
+| `max_cores`       | Max parallel workers (NULL = auto-detect: `available_cores - 2`, floor 1) |
 | `n_lvl1`          | Level 1 sample sizes (repeated measures)               |
 | `n_lvl2`          | Level 2 sample sizes (individuals)                     |
 | `lvl1_effect_std` | Standardized L1 direct effect sizes                    |
@@ -113,7 +113,7 @@ The program uses YAML configuration files in [`configs/`](configs/) to define th
 | `return_df`       | Return results as data frame (TRUE for grid runner)    |
 | `rand_seed`       | Base random seed (each combination gets seed + run_id) |
 
-**Parallel execution.** The `max_cores` parameter caps parallel workers. If NULL, the program defaults to `min(4, available_cores - 4)`. If set, it is capped at `available_cores - 2`. BLAS threads are pinned to 1 per worker via `RhpcBLASctl` to prevent oversubscription.
+**Parallel execution.** The `max_cores` parameter caps parallel workers. If NULL, the program defaults to `available_cores - 2` (floor of 1), using all available capacity. If set, it is capped at `available_cores - 2`. BLAS threads are pinned to 1 per worker via `RhpcBLASctl` to prevent oversubscription.
 
 **Reproducibility.** Each parameter combination receives a unique seed derived from `rand_seed + run_id`, where `run_id` is the row number in the factorial grid. This ensures reproducibility while avoiding seed collisions across combinations.
 
@@ -141,7 +141,7 @@ nohup bash analysis/run_power_analysis/main.sh prod_gcp &
 ### What happens at runtime
 
 1. `main.sh` creates a timestamped log file in `logs/` and starts the wall-clock timer.
-2. `main.sh` hands off to `Rscript run_power_analysis.r --version <dev|prod>`.
+2. `main.sh` hands off to `Rscript run_power_analysis.R --version <dev|prod|benchmark_gcp|prod_gcp>`.
 3. The R script activates `renv` via the project-root [`.Rprofile`](../../.Rprofile), resolves all paths from its own filesystem location, and loads the version-specific configuration.
 4. A full factorial parameter grid is built via `tidyr::expand_grid()` and its size is logged.
 5. System information (OS, cores, memory) is logged.
@@ -209,7 +209,7 @@ Reference benchmarks:
 | `prod`    | MacBook Pro M1 Max       | 1,215    | 6 of 10    | ~18.5 hours     |
 | `prod_gcp`| GCP `c3-highcpu-176`     | 3,645    | 174 of 176 | ~7 hours 10 min |
 
-Runtime scales roughly inversely with core count. Use `benchmark_gcp` to calibrate on a new VM: `speedup = 61.2 / gcp_wall_min`; then `prod_hours = grid_cells / (workers x speedup)`. Set `max_cores` in the config to the VM's vCPU count minus 2.
+Runtime scales roughly inversely with core count. Use `benchmark_gcp` to calibrate on a new VM: `prod_min ≈ benchmark_min × 100` (the benchmark runs 729 cells × 50 sims; prod_gcp runs 3,645 cells × 1,000 sims -- a 100× difference -- at the same auto-detected worker count). Core count is auto-detected (`available_cores - 2`); hardcode `max_cores` in the config only to override.
 
 The program logs system info at startup so you can verify core allocation.
 </details>

--- a/analysis/run_power_analysis/configs/run_power_analysis.benchmark_gcp.yaml
+++ b/analysis/run_power_analysis/configs/run_power_analysis.benchmark_gcp.yaml
@@ -1,9 +1,9 @@
 # * Power Analysis Configuration
-# * Version: Benchmark GCP (calibrate per-core GCP speed vs university VM)
-# * Uses 14 workers intentionally — matches university benchmark for direct comparison
-# * Calibration: speedup = 61.2 / gcp_wall_min; prod_hours = 1426 / (174 × speedup)
+# * Version: Benchmark GCP (timing probe to calibrate expected runtime on any VM)
+# * Grid: 729 cells x 50 sims = 36,450 total sims (100x smaller than prod_gcp)
+# * Calibration: prod_min ~= benchmark_min x 100 (same worker count; linear scaling)
 params:
-  max_cores: 14 # intentionally matches university worker count for speed comparison
+  max_cores: # auto-detect (available_cores - 2); hardcode only to override
   n_lvl1: [3]
   n_lvl2: [200, 800, 1500]
   lvl1_effect_std: [0.10, 0.30, 0.50]

--- a/analysis/run_power_analysis/configs/run_power_analysis.dev.yaml
+++ b/analysis/run_power_analysis/configs/run_power_analysis.dev.yaml
@@ -1,7 +1,7 @@
 # * Power Analysis Configuration
 # * Version: Dev
 params:
-  max_cores: # ! ADJUST AS NEEDED; default (i.e., NULL) is conserved at 4 cores
+  max_cores: # ! ADJUST AS NEEDED; default (NULL) auto-detects available_cores - 2
   n_lvl1: [3]
   n_lvl2: [100, 200, 300]
   lvl1_effect_std: [0.30]

--- a/analysis/run_power_analysis/configs/run_power_analysis.prod.yaml
+++ b/analysis/run_power_analysis/configs/run_power_analysis.prod.yaml
@@ -1,7 +1,7 @@
 # * Power Analysis Configuration
 # * Version: Prod
 params:
-  max_cores: # ! ADJUST AS NEEDED: currently set up for GCP VM run
+  max_cores: # ! ADJUST AS NEEDED; default (NULL) auto-detects available_cores - 2
   n_lvl1: [3]
   n_lvl2: [200, 400, 600, 800, 1000]
   lvl1_effect_std: [0.10, 0.30, 0.50]

--- a/analysis/run_power_analysis/configs/run_power_analysis.prod_gcp.yaml
+++ b/analysis/run_power_analysis/configs/run_power_analysis.prod_gcp.yaml
@@ -1,8 +1,9 @@
 # * Power Analysis Configuration
-# * Version: Prod GCP (single large VM — full 3,645-cell grid)
-# * Recommended instance: c3-highcpu-176 (174 workers = 176 vCPUs - 2)
+# * Version: Prod GCP (single large VM -- full 3,645-cell grid)
+# * Recommended instance: c3-highcpu-176 (auto-detect yields 174 workers = 176 vCPUs - 2)
+# * Hardcode max_cores only if overriding auto-detection (e.g., to reserve extra capacity)
 params:
-  max_cores: 174 # c3-highcpu-176; set to your instance's vCPUs - 2
+  max_cores: # auto-detect (available_cores - 2); on c3-highcpu-176 this yields 174 workers
   n_lvl1: [3]
   n_lvl2: [100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1100, 1200, 1300, 1400, 1500]
   lvl1_effect_std: [0.10, 0.30, 0.50]

--- a/analysis/run_power_analysis/main.sh
+++ b/analysis/run_power_analysis/main.sh
@@ -36,7 +36,7 @@ echo "[$(date '+%Y-%m-%d %H:%M:%S')] Starting run_power_analysis (version: ${ver
 echo "[$(date '+%Y-%m-%d %H:%M:%S')] Log file: ${log_file}"
 
 # hand off to R -- all orchestration logic lives there
-Rscript "${script_dir}/scripts/run_power_analysis.r" --version "${version}" 2>&1
+Rscript "${script_dir}/scripts/run_power_analysis.R" --version "${version}" 2>&1
 
 exit_code=$?
 

--- a/analysis/run_power_analysis/scripts/run_power_analysis.r
+++ b/analysis/run_power_analysis/scripts/run_power_analysis.r
@@ -1,12 +1,12 @@
 #!/usr/bin/env Rscript
 
 # ---------------------------------------------------------------------------
-# run_power_analysis.r - Orchestration script for power analysis grid
+# run_power_analysis.R - Orchestration script for power analysis grid
 #
 # Builds a full factorial parameter grid from config, distributes across
 # parallel workers via furrr, and saves timestamped results.
 #
-# Usage: Rscript run_power_analysis.r --version <dev|prod|benchmark_gcp|prod_gcp>
+# Usage: Rscript run_power_analysis.R --version <dev|prod|benchmark_gcp|prod_gcp>
 #        (Normally invoked by main.sh, not called directly)
 # ---------------------------------------------------------------------------
 
@@ -34,7 +34,7 @@ version <- args$version
 # [2] Path resolution -----------------------------------------------------
 
 # Derive all paths from this script's filesystem location.
-# Expected location: analysis/run_power_analysis/scripts/run_power_analysis.r
+# Expected location: analysis/run_power_analysis/scripts/run_power_analysis.R
 
 resolve_paths <- function(version) {
     # Get the directory containing this script
@@ -46,7 +46,7 @@ resolve_paths <- function(version) {
         script_path <- normalizePath(sub("^--file=", "", file_arg))
     } else {
         # Sourced interactively -- fall back to working directory
-        script_path <- normalizePath(file.path(getwd(), "scripts", "run_power_analysis.r"))
+        script_path <- normalizePath(file.path(getwd(), "scripts", "run_power_analysis.R"))
     }
 
     scripts_dir <- dirname(script_path)
@@ -79,7 +79,7 @@ resolve_paths <- function(version) {
         }
     }
 
-    utils_file <- file.path(paths$utils_dir, "power_analysis_utils.r")
+    utils_file <- file.path(paths$utils_dir, "power_analysis_utils.R")
     if (!file.exists(utils_file)) {
         stop(paste0("Required file not found: ", utils_file))
     }
@@ -93,7 +93,7 @@ paths <- resolve_paths(version)
 # [3] Source dependencies -------------------------------------------------
 
 source(paths$common_utils)
-source(file.path(paths$utils_dir, "power_analysis_utils.r"))
+source(file.path(paths$utils_dir, "power_analysis_utils.R"))
 
 # Ensure runtime directories exist
 ensure_dir(paths$data_dir)
@@ -115,7 +115,7 @@ log_msg("")
 
 # [5] Load config and build parameter grid --------------------------------
 
-# Import remaining packages (common_utils.r and power_analysis_utils.r
+# Import remaining packages (common_utils.r and power_analysis_utils.R
 # already loaded their own dependencies)
 library(dplyr)
 library(furrr)
@@ -164,7 +164,7 @@ RhpcBLASctl::blas_set_num_threads(1)
 n_cores <- if (!is.null(config$params$max_cores)) {
     min(config$params$max_cores, parallelly::availableCores() - 2L)
 } else {
-    min(4L, max(1L, parallelly::availableCores() - 4L))
+    max(1L, parallelly::availableCores() - 2L)
 }
 
 if (.Platform$OS.type == "unix") {

--- a/analysis/run_power_analysis/utils/power_analysis_utils.r
+++ b/analysis/run_power_analysis/utils/power_analysis_utils.r
@@ -1,7 +1,7 @@
 #!/usr/bin/env Rscript
 
 # ---------------------------------------------------------------------------
-# power_analysis_utils.r - Simulation engine for two-level power analysis
+# power_analysis_utils.R - Simulation engine for two-level power analysis
 #
 # Based on: Arend & Schafer (2019)
 # Implements Monte Carlo power simulations using simr with Kenward-Roger

--- a/analysis/tests/validate_r_structure.sh
+++ b/analysis/tests/validate_r_structure.sh
@@ -108,8 +108,8 @@ echo "----------------------------------------------------------------------"
 
 required_files=(
 	"analysis/run_power_analysis/main.sh"
-	"analysis/run_power_analysis/scripts/run_power_analysis.r"
-	"analysis/run_power_analysis/utils/power_analysis_utils.r"
+	"analysis/run_power_analysis/scripts/run_power_analysis.R"
+	"analysis/run_power_analysis/utils/power_analysis_utils.R"
 	"analysis/run_power_analysis/configs/run_power_analysis.dev.yaml"
 	"analysis/run_power_analysis/configs/run_power_analysis.prod.yaml"
 	"analysis/shared/utils/common_utils.r"
@@ -149,10 +149,10 @@ if [ -f "${main_sh}" ]; then
 		fail "main.sh does not pass --version flag to Rscript"
 	fi
 
-	if grep -q 'scripts/run_power_analysis.r' "${main_sh}"; then
+	if grep -q 'scripts/run_power_analysis.R' "${main_sh}"; then
 		pass "main.sh references correct R script path"
 	else
-		fail "main.sh does not reference scripts/run_power_analysis.r"
+		fail "main.sh does not reference scripts/run_power_analysis.R"
 	fi
 else
 	fail "Cannot check main.sh -- file missing"
@@ -165,7 +165,7 @@ echo "5. Path resolution alignment"
 echo "----------------------------------------------------------------------"
 
 # Simulate what resolve_paths() in R would compute
-r_script="analysis/run_power_analysis/scripts/run_power_analysis.r"
+r_script="analysis/run_power_analysis/scripts/run_power_analysis.R"
 if [ -f "${r_script}" ]; then
 	scripts_dir="$(dirname "${r_script}")"
 	program_dir="$(dirname "${scripts_dir}")"
@@ -181,7 +181,7 @@ if [ -f "${r_script}" ]; then
 	derived_common="${analysis_dir}/shared/utils/common_utils.r"
 	derived_config_dev="${program_dir}/configs/run_power_analysis.dev.yaml"
 	derived_config_prod="${program_dir}/configs/run_power_analysis.prod.yaml"
-	derived_utils="${program_dir}/utils/power_analysis_utils.r"
+	derived_utils="${program_dir}/utils/power_analysis_utils.R"
 
 	if [ -f "${derived_common}" ]; then
 		pass "Derived common_utils path resolves: ${derived_common}"
@@ -219,8 +219,8 @@ echo "----------------------------------------------------------------------"
 if command -v Rscript &>/dev/null; then
 	r_files=(
 		"analysis/shared/utils/common_utils.r"
-		"analysis/run_power_analysis/utils/power_analysis_utils.r"
-		"analysis/run_power_analysis/scripts/run_power_analysis.r"
+		"analysis/run_power_analysis/utils/power_analysis_utils.R"
+		"analysis/run_power_analysis/scripts/run_power_analysis.R"
 	)
 
 	for f in "${r_files[@]}"; do
@@ -246,8 +246,8 @@ echo "----------------------------------------------------------------------"
 
 code_files=(
 	"analysis/shared/utils/common_utils.r"
-	"analysis/run_power_analysis/utils/power_analysis_utils.r"
-	"analysis/run_power_analysis/scripts/run_power_analysis.r"
+	"analysis/run_power_analysis/utils/power_analysis_utils.R"
+	"analysis/run_power_analysis/scripts/run_power_analysis.R"
 	"analysis/run_power_analysis/main.sh"
 )
 

--- a/gcp/CLAUDE.md
+++ b/gcp/CLAUDE.md
@@ -55,7 +55,8 @@ python gcp/deploy/manage_compute.py teardown         # delete VM (warns if resul
 
 ## Schema change workflow
 
-`models/qualtrics.py` → `bq_schemas.py` → `web_service_payload.json` fixture → `test_models.py` → `manage_infra.py teardown` → `manage_infra.py setup`
+Intake: `models/qualtrics.py` → `bq_schemas.py` → `web_service_payload.json` fixture → `test_models.py` → `manage_infra.py teardown` → `manage_infra.py setup`
+Followup: `models/followup.py` → `bq_schemas.py` → `followup_web_service_payload.json` fixture → `test_followup_response.py` → `manage_infra.py teardown` → `manage_infra.py setup`
 
 Schema changes require BQ table teardown/recreate (streaming API limitation).
 

--- a/gcp/README.md
+++ b/gcp/README.md
@@ -18,7 +18,7 @@ Survey response ETL pipeline for a longitudinal ESM study. Receives Qualtrics We
   - [Dependencies](#dependencies)
   - [Adding a new function](#adding-a-new-function)
 
-Three Cloud Run functions live under `cloud_run_functions/`, each with its own `main.py` and `configs/`. Shared utilities (`bq_schemas.py`, `config_loader.py`, `pubsub_utils.py`, etc.) live in `shared/utils/`. Deployment scripts and YAML configs live in `deploy/`. Tests under `tests/` are fully mocked — no GCP credentials or network access needed.
+Four Cloud Run functions live under `cloud_run_functions/`, each with its own `main.py` and `configs/`. Shared utilities (`bq_schemas.py`, `config_loader.py`, `pubsub_utils.py`, etc.) live in `shared/utils/`. Deployment scripts and YAML configs live in `deploy/`. Tests under `tests/` are fully mocked — no GCP credentials or network access needed.
 
 ## How it works
 
@@ -31,6 +31,8 @@ A participant completes the intake survey in Qualtrics, which triggers a Workflo
 **Function 2: `run_intake_confirmation`** ([main.py](cloud_run_functions/run_intake_confirmation/main.py)) — Pub/Sub trigger on `dkg-intake-processed`. Decodes the CloudEvent message, checks BigQuery for idempotency (`_processed` flag), sends an SMS via Twilio confirming the participant's follow-up schedule, publishes a `FollowupSchedulingMessage` to `dkg-followup-scheduling`, and updates `_processed = TRUE`. If SMS fails, the function raises so Pub/Sub retries with exponential backoff. Malformed messages are acknowledged to prevent infinite retries.
 
 **Function 3: `run_followup_scheduling`** ([main.py](cloud_run_functions/run_followup_scheduling/main.py)) — Pub/Sub trigger on `dkg-followup-scheduling`. Checks the `scheduled_followups` BigQuery table for idempotency (keyed by `response_id`). Builds three survey URLs with participant-specific query parameters (Connect ID, response ID, survey number). Schedules three SMS messages via the Twilio Message Scheduling API — one for each daily time slot (9:00 AM, 1:00 PM, 5:00 PM in the participant's local timezone). Writes scheduling records (Twilio message SIDs) to BigQuery only after all three Twilio calls succeed. A `send_immediately` test flag (set via `manage_gateway.py test --now`) bypasses fixed times and schedules at now+16/32/48 min for rapid end-to-end testing.
+
+**Function 4: `run_followup_response`** ([main.py](cloud_run_functions/run_followup_response/main.py)) — HTTP trigger, fronted by the API Gateway at the `/followup` path. This is the terminal inbound endpoint for completed ESM survey responses. All three daily surveys (9AM/1PM/5PM) POST to this endpoint; the `timepoint` field in the payload distinguishes them. Validates the incoming JSON against `FollowupWebServicePayload` (a Pydantic model in `models/followup.py`) and writes to the `followup_raw` BigQuery table via `FOLLOWUP_RESPONSES_SCHEMA`. No Twilio, no Pub/Sub publishing. Validation failures return 400; successful writes return 200 with `response_id` and `timepoint`.
 
 ## CLI tools
 
@@ -312,6 +314,7 @@ Dependencies are managed by Poetry with dependency groups:
 - `fn-qualtrics-scheduling`: Intake webhook (Flask, functions-framework, google-cloud-bigquery, google-cloud-pubsub).
 - `fn-intake-confirmation`: SMS confirmation (functions-framework, google-cloud-bigquery, twilio, cloudevents).
 - `fn-followup-scheduling`: Follow-up SMS scheduling (functions-framework, google-cloud-bigquery, twilio, cloudevents).
+- `fn-followup-response`: Followup response ingestion (functions-framework, google-cloud-bigquery). No Twilio or Pub/Sub.
 - `dev`: Development tools (pytest, pytest-cov, ruff, radian).
 
 At deploy time, `manage_functions.py` exports `main` + the function's group into a `requirements.txt` that Cloud Run uses to build the container. New functions get their own Poetry group and an entry in [`functions.yaml`](deploy/functions.yaml).


### PR DESCRIPTION
Corrects file extension case (run_power_analysis.R, power_analysis_utils.R) for Linux compatibility and replaces the hardcoded conservative core ceiling with automatic detection (available_cores - 2), machine-agnostic benchmark calibration, and config-level override support. Fills a documentation gap where run_followup_response (the fourth Cloud Run function) was absent from gcp/README.md, root README.md, gcp/CLAUDE.md, root CLAUDE.md, and the Makefile. Cleans up analysis/CLAUDE.md and the Makefile to match current codebase state.

Accuracy:
- Remove stale worker counts from help (benchmark/prod_gcp now auto-detect)
- Add run_followup_response to help_gcp function list
- Add followup schema change workflow to help_gcp alongside intake workflow

Coverage:
- Add gcp_infra_status, gcp_pubsub_status, gcp_gateway_status targets (scripts support status subcommand; now surfaced in help_gcp)

Cleanup:
- Remove py_install (redundant with setup_python, undocumented in help)
- Fix validate invocation: bash $(ROOT)/analysis/tests/validate_r_structure.sh (consistent with all other targets; removes unnecessary cd)
- Add __pycache__ removal to clean target