### PR TITLE
docs: dashboard README, study analysis track, and doc fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # CLAUDE.md
 
 PhD dissertation: within-person fluctuation in burnout, need frustration, and turnover intentions.
-Three pillars: `gcp/` (Python GCP pipeline), `analysis/run_power_analysis/` (R simulations), `analysis/run_synthetic_data/` (test data).
+Components: `gcp/` (Python GCP pipeline), `analysis/run_power_analysis/` (R simulations), `analysis/run_study_analysis/` (real-data dissertation analysis), `analysis/run_synthetic_data/` (test data), `dashboard/` (interactive results dashboard).
 Python >=3.12,<3.13 (uv) and R >= 4.4 (uvr) managed separately. `.python-version` pins `3.12.11` for pyenv.
 See `gcp/CLAUDE.md` and `analysis/CLAUDE.md` for domain specifics.
 

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ FN ?= run-qualtrics-scheduling
         study_export \
         study_analysis study_data_quality \
         study_eda study_measurement \
-        study_mlm study_correlation study_tables \
+        study_mlm study_correlation study_tables study_all \
         py_lint py_format py_sqlfmt py_test \
         gcp_dev gcp_deploy \
         gcp_infra_up gcp_infra_status gcp_infra_down \

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ Author & Maintainer: Demetrius K. Green
 
 [Email](mailto:dkgreen.iopsych@gmail.com) | ![github pic](https://raw.githubusercontent.com/CLorant/readme-social-icons/main/small/filled/github.svg) [GitHub](https://github.com/datasci-iopsy) | ![linkedin pic](https://raw.githubusercontent.com/CLorant/readme-social-icons/main/small/filled/linkedin.svg) [LinkedIn](https://www.linkedin.com/in/dkgreen-io/) | [ResearchGate](https://www.researchgate.net/profile/Demetrius-Green-2)
 
-A dissertation **TO BE** submitted to the Graduate Faculty of North Carolina State University in partial fulfillment of the requirements for the degree of Doctor of Philosophy.
+**Results Dashboard:** <https://esm-study-dashboard.netlify.app/>
+
+A dissertation submitted to the Graduate Faculty of North Carolina State University in partial fulfillment of the requirements for the degree of Doctor of Philosophy.
 
 Industrial-Organizational Psychology
 
@@ -109,6 +111,22 @@ make synthetic_analysis    # Synthetic data: EDA → correlation → measurement
 See `analysis/run_power_analysis/README.md` for the full parameter grid and configuration.
 See `analysis/run_synthetic_data/README.md` for synthetic data inputs and outputs.
 
+Study data (the official pipeline on real participant data from BigQuery):
+
+```bash
+make study_export         # Rebuild BQ fact tables, re-export CSVs (prompts for confirmation)
+make study_data_quality   # 1. Careless responding screening -> cleaned CSV
+make study_eda            # 2. Exploratory data analysis
+make study_correlation    # 3. Correlation analysis
+make study_measurement    # 4. Measurement model (CFA)
+make study_mlm            # 5. Multilevel model (main analysis)
+make study_analysis       # Steps 1-5 in sequence (study_data_quality through study_mlm)
+make study_tables         # 6. Publication-ready Word tables
+make study_all            # Full study pipeline: export -> steps 1-5 -> tables (guaranteed fresh)
+```
+
+See `analysis/run_study_analysis/README.md` for the data pipeline, careless-responding screening, and variable definitions.
+
 ### Track B — Python Development (Testing, Linting, Local Dev Server)
 
 Requires Quick Start steps 1–3. No GCP credentials needed — all tests are fully mocked.
@@ -154,8 +172,9 @@ See `make help_gcp` for the full GCP command reference.
 Requires Track B + `gcloud` CLI. The VM is Linux-only and is used solely for R simulations.
 
 ```bash
-uv run gcp/deploy/manage_compute.py setup   # Create VM (c3-highcpu-176)
-uv run gcp/deploy/manage_compute.py ssh     # SSH in
+make gcp_compute_up      # Create VM (c3-highcpu-176)
+make gcp_compute_status  # Show VM state + external IP
+make gcp_compute_ssh     # SSH in
 ```
 
 On the VM (run once after first SSH):
@@ -175,11 +194,15 @@ nohup make power_analysis_gcp_prod &       # Full grid in background (3,645 cell
 After completion:
 
 ```bash
-uv run gcp/deploy/manage_compute.py scp      # Download results to local machine
-uv run gcp/deploy/manage_compute.py teardown # Delete VM to stop billing
+make gcp_compute_scp     # Download results to local machine
+make gcp_compute_down    # Delete VM to stop billing
 ```
 
 See `analysis/run_power_analysis/README.md` for benchmarks and troubleshooting.
+
+### Track E: Results Dashboard
+
+Results from the study analysis are presented as an interactive dashboard, live at <https://esm-study-dashboard.netlify.app/>. It is a static, client-side app deployed on Netlify from `dashboard/`; there is no setup track to run here beyond what Quick Start already provides. See [`dashboard/README.md`](dashboard/README.md) for what it shows, how its data is built, and how to run or deploy it.
 
 ## Dependency Management
 
@@ -212,6 +235,7 @@ For a full command reference: `make help` (all commands) or `make help_gcp` (GCP
     - [Track B — Python Development (Testing, Linting, Local Dev Server)](#track-b--python-development-testing-linting-local-dev-server)
     - [Track C — GCP Deployment](#track-c--gcp-deployment)
     - [Track D — GCP VM for Large Power Analysis](#track-d--gcp-vm-for-large-power-analysis)
+    - [Track E: Results Dashboard](#track-e-results-dashboard)
   - [Dependency Management](#dependency-management)
   - [Troubleshooting](#troubleshooting)
 - [Table of Contents](#table-of-contents)

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -1,0 +1,57 @@
+# dashboard/
+
+**Live:** <https://esm-study-dashboard.netlify.app/>
+
+Interactive, client-side results dashboard for the dissertation. It presents a static snapshot of the study analysis (frozen 2026-06-12, the submission snapshot) as a tabbed single-page app: no server-side code, no build step, just HTML/CSS/JS reading a pre-built JSON file.
+
+- [What it shows](#what-it-shows)
+- [How the data is built](#how-the-data-is-built)
+- [Running it locally](#running-it-locally)
+- [Deployment](#deployment)
+- [Data snapshot](#data-snapshot)
+
+## What it shows
+
+`index.html` renders 10 tabs, each backed by data in `data/dashboard.json` and drawn with Chart.js 4 (loaded from CDN) plus plain HTML/CSS for tables and cards:
+
+1. **The Study**, conceptual research model and design overview
+2. **The Sample**, participant counts, recruitment funnel, demographics
+3. **Correlations**, within-person and between-person correlation matrices
+4. **Variance Story**, ICC and variance decomposition by construct
+5. **Measurement**, CFA fit, reliability, marker-variable and invariance checks
+6. **Model Explorer**, fit statistics and fixed effects across the M0-M7b model sequence
+7. **Effect Sizes**, standardized and level-specific effect sizes, forest plot
+8. **Hypotheses**, a scorecard of the 17 directional hypotheses
+9. **Discussion**, takeaways and future directions
+10. **Limitations**, study limitations in plain language
+
+## How the data is built
+
+`data/dashboard.json` is generated from the frozen study-analysis outputs, never hand-written:
+
+```bash
+uv run dashboard/scripts/build_dashboard_data.py
+```
+
+The script reads CSVs under `../analysis/run_study_analysis/figs/{eda,corr,mlm,cfa}/`, writes the single output file `data/dashboard.json`, and validates a set of anchor values (participant count, observation count, ICC, hypothesis tally, model counts) before exiting, failing loudly if the frozen CSVs and the hardcoded anchors disagree. It has no dependencies beyond the Python standard library.
+
+The full mapping from each JSON key to its source CSV is documented in [`data/MANIFEST.md`](data/MANIFEST.md); that file is the source of truth for provenance, not this README.
+
+## Running it locally
+
+The page fetches `data/dashboard.json` at runtime, so opening `index.html` directly via `file://` will not work (the fetch is blocked by browser same-origin rules). Serve it over HTTP from this directory instead:
+
+```bash
+cd dashboard
+netlify dev
+# or, without the Netlify CLI:
+python -m http.server
+```
+
+## Deployment
+
+Deployed to Netlify as a static site. `netlify.toml` sets `publish = "."` with no build command, the committed `data/dashboard.json` is what ships; there is no CI build step. `.netlify/` is local Netlify CLI scratch state and is not part of the deployed app.
+
+## Data snapshot
+
+This dashboard reflects the 2026-06-12 submission snapshot: N = 336 participants, n = 1,008 observations, ICC(TI) approximately 0.79, 7 of 17 hypotheses supported. To regenerate against a newer analysis run, rerun the study pipeline (`make study_all` from the project root, see [`../analysis/run_study_analysis/README.md`](../analysis/run_study_analysis/README.md)) and then rerun the build script above.


### PR DESCRIPTION
## Summary

Brings the project docs current with the repo's actual state now that the dissertation has been defended and submitted, and the results dashboard has shipped. A documentation audit found the root README and CLAUDE.md still described a proposed, in-progress project with no mention of the dashboard or the real-data study analysis pipeline.

## Changes

### Documentation
- Add `dashboard/README.md`: what the dashboard shows (10 tabs, Chart.js 4), how `data/dashboard.json` is built and validated, how to run it locally over HTTP, how it deploys on Netlify, and the 2026-06-12 data snapshot
- Add the live dashboard URL (`esm-study-dashboard.netlify.app`) to the root README and `dashboard/README.md`
- Add a "Results Dashboard" pointer (Track E) to the root README linking to `dashboard/README.md`, rather than explaining the dashboard inline
- Add the missing Study Data Analysis targets (`study_export`, `study_data_quality`, `study_eda`, `study_correlation`, `study_measurement`, `study_mlm`, `study_analysis`, `study_tables`, `study_all`) to Track A of the root README
- Convert Track D's GCP VM commands from raw `uv run gcp/deploy/manage_compute.py ...` calls to the equivalent `make gcp_compute_*` targets
- Update the root `CLAUDE.md` component list to include `run_study_analysis/` and `dashboard/` (previously only listed three of five top-level components)
- Update the README title to reflect that the dissertation has been submitted, not "TO BE submitted"

### Fixes
- Add `study_all` to the Makefile `.PHONY` declarations (it was a real target, shown in `make help`, but missing from `.PHONY`)

## Dev workflow

No behavior changes; all edits are documentation plus the one-line `.PHONY` fix. `make help` still lists every target correctly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated project docs to reflect the post-defense/submitted dissertation state and the newly shipped results dashboard.

- Added `dashboard/README.md` documenting the static dashboard, its tabs, how `data/dashboard.json` is generated/validated from frozen study outputs, local HTTP usage, Netlify deployment, and the current data snapshot.
- Revised `README.md` to point to the live dashboard, add Track E docs, expand Track A study-data targets, switch Track D VM instructions to `make` targets, and update the dissertation wording/title.
- Updated `CLAUDE.md` to list `analysis/run_study_analysis/` and `dashboard/` in the project overview.
- Fixed `Makefile` phony declarations by adding `study_all`.

Safety / compatibility notes:
- Dashboard docs assume the JSON schema in `data/dashboard.json` matches the build script and frozen CSV provenance; if those inputs drift, validation will fail.
- The dashboard is intended to be served over HTTP, not opened via `file://`, and Netlify is configured as a static publish of the repo root.
- The `make`-based VM/scp/down commands replace direct script invocation in the docs, so any local workflow using the old commands should be updated accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->